### PR TITLE
TECH-2055: Do not use <template:module> for HTML attributes

### DIFF
--- a/src/main/resources/jdmix_favicon/html/favicon.favicon.jsp
+++ b/src/main/resources/jdmix_favicon/html/favicon.favicon.jsp
@@ -20,6 +20,7 @@
 
 <c:set var="siteNode" value="${renderContext.site}"/>
 <c:set var="icon" value="${siteNode.properties['icon'].node}"/>
-<template:module node='${icon}' editable='false' view='hidden.contentURL' var="iconUrl"/>
+<template:addCacheDependency node="${icon}"/>
+<c:url var="iconUrl" value="${icon.url}" context="/"/>
 
 <link rel="shortcut icon" href="${iconUrl}" type="image/x-icon">

--- a/src/main/resources/jdnt_logo/html/logo.jsp
+++ b/src/main/resources/jdnt_logo/html/logo.jsp
@@ -18,8 +18,10 @@
 
 <c:if test="${not empty logo}">
     <c:if test="${not empty renderContext.site.home.url}">
-        <template:module node='${renderContext.site.home}' editable='false' view='hidden.contentURL' var="homePageURL"/>
-        <template:module node='${logo}' editable='false' view='hidden.contentURL' var="logoUrl"/>
+        <template:addCacheDependency node="${renderContext.site.home}"/>
+        <c:url var="homePageURL" value="${renderContext.site.home.url}" context="/"/>
+        <template:addCacheDependency node="${logo}"/>
+        <c:url var="logoUrl" value="${logo.url}" context="/" />
     </c:if>
     <a href="${homePageURL}" class="logo"><img src="${logoUrl}" alt="Logo"></a>
 </c:if>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/TECH-2055

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Replace the usages of `<template:module>` used as HTML tags attributes, as it prevents the `HtmlTagAttributeVisitor` visitors (in particular the `UrlRewriteVisitor`) to be called for those tags, causing issues with _Cloudimage_ that relies on URL rewrite rules.
Similar to https://github.com/Jahia/jahia-base-demo-components/pull/29.
